### PR TITLE
Add to slack button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
+.DS_Store
 /node_modules

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ thanksbot is an open source chat app for Slack that records individual messages 
 
 ## Add to Slack
 
-<a href="https://slack.com/oauth/v2/authorize?client_id=962050889920.989827594197&scope=app_mentions:read,channels:history,channels:join,channels:manage,chat:write,chat:write.customize,groups:history,im:history,im:read,im:write,incoming-webhook&redirect_uri=https://cf026c2a.ngrok.io/slack/auth">
+<a href="https://slack.com/oauth/v2/authorize?client_id=962050889920.989827594197&scope=app_mentions:read,channels:history,channels:join,channels:manage,chat:write,chat:write.customize,groups:history,im:history,im:read,im:write,incoming-webhook,channels:read&redirect_uri=https://cf026c2a.ngrok.io/slack/auth">
     <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x">
 </a>
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# meet thanksbot
+
+thanksbot is an open source chat app for Slack that records individual messages of affirmation and shares them periodically with your workspace.
+
+## Getting Started
+
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
+
+### Prerequisites
+
+What things you need to install the software and how to install them
+
+```
+Give examples
+```
+
+### Installing
+
+A step by step series of examples that tell you how to get a development env running
+
+Say what the step will be
+
+```
+Give the example
+```
+
+And repeat
+
+```
+until finished
+```
+
+End with an example of getting some data out of the system or using it for a little demo
+
+## Running the tests
+
+Explain how to run the automated tests for this system
+
+### Break down into end to end tests
+
+Explain what these tests test and why
+
+```
+Give an example
+```
+
+### And coding style tests
+
+Explain what these tests test and why
+
+```
+Give an example
+```
+
+## Deployment
+
+Add additional notes about how to deploy this on a live system
+
+## Built With
+
+* 
+
+## Contributing
+
+Try thanksbot out in your organization or community workspace (you may need to get a workspace administrator to install it for you): 
+
+* If you find a bug, or think of a feature request, [file an issue]() first so we can document it.
+* Want to send in a PR? Fork the repo and issue a PR from your fork:
+  * Please cite any issues the PR addresses from the [issue tracker]()
+  * Please lint your code before submitting
+  * Please test your code locally before submitting 
+* Wait for review - we will try to review PRs within 5 days of submission, but please be patient.
+
+thanksbot is maintained by [@jorydotcom]() and [@ktbee](). 
+
+## License
+
+This project is licensed under the Apache 2.0 License - see the [LICENSE.md](LICENSE.md) file for details.
+
+## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -3,11 +3,17 @@
 thanksbot is an open source chat app for Slack that records individual messages of affirmation and shares them periodically with your workspace.
 
 ## Add to Slack
-
+<!-- 
 
 <a href="https://slack.com/oauth/authorize?scope=incoming-webhook,bot&client_id=962050889920.989827594197&redirect_uri=https://cf026c2a.ngrok.io/slack/auth">
     <img alt=""Add to Slack"" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
+</a> -->
+
+<a href="https://slack.com/oauth/v2/authorize?client_id=962050889920.989827594197&scope=app_mentions:read,channels:history,channels:join,channels:manage,chat:write,chat:write.customize,groups:history,im:history,im:read,im:write,incoming-webhook&redirect_uri=https://cf026c2a.ngrok.io/slack/auth">
+    <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x">
 </a>
+
+
 
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 thanksbot is an open source chat app for Slack that records individual messages of affirmation and shares them periodically with your workspace.
 
 ## Add to Slack
-<!-- 
-
-<a href="https://slack.com/oauth/authorize?scope=incoming-webhook,bot&client_id=962050889920.989827594197&redirect_uri=https://cf026c2a.ngrok.io/slack/auth">
-    <img alt=""Add to Slack"" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
-</a> -->
 
 <a href="https://slack.com/oauth/v2/authorize?client_id=962050889920.989827594197&scope=app_mentions:read,channels:history,channels:join,channels:manage,chat:write,chat:write.customize,groups:history,im:history,im:read,im:write,incoming-webhook&redirect_uri=https://cf026c2a.ngrok.io/slack/auth">
     <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x">

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 thanksbot is an open source chat app for Slack that records individual messages of affirmation and shares them periodically with your workspace.
 
+## Add to Slack
+
+
+<a href="https://slack.com/oauth/authorize?scope=incoming-webhook,bot&client_id=962050889920.989827594197&redirect_uri=https://cf026c2a.ngrok.io/slack/auth">
+    <img alt=""Add to Slack"" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" />
+</a>
+
+
 ## Getting Started
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.

--- a/bot/dbConfig.js
+++ b/bot/dbConfig.js
@@ -1,0 +1,16 @@
+require('dotenv').config();
+const devConfig = require('../database.json').dev;
+
+exports.getDbConfig = function() {
+    // This is the environment variable Heroku exposes
+    const connectionString = process.env.DATABASE_URL;
+    if (connectionString) {
+        return {
+            connectionString,
+            ssl: true,
+            sslmode: 'require'
+        };
+    }
+
+    return devConfig;
+};

--- a/bot/slackAuth.js
+++ b/bot/slackAuth.js
@@ -1,0 +1,35 @@
+require('dotenv').config();
+const fetch = require('node-fetch');
+const { Pool, Client } = require('pg');
+
+const pool = new Pool(process.env.DATABASE_URL);
+
+exports.authResponse = async function(req, res) {
+    const { code } = req.query;
+    const slackURL =
+        'https://slack.com/api/oauth.v2.access?code=' +
+        code +
+        '&client_id=' +
+        process.env.SLACK_CLIENT_ID +
+        '&client_secret=' +
+        process.env.SLACK_CLIENT_SECRET +
+        '&redirect_uri=' +
+        process.env.SLACK_REDIRECT_URI;
+    const authResponse = await fetch(slackURL).then(res => res.json());
+    console.log('authResponse', authResponse);
+    if (!authResponse.ok) {
+        console.log(authResponse);
+        res.send('Error encountered: \n' + JSON.stringify(authResponse))
+            .status(200)
+            .end();
+    } else {
+        // TO DO: better celebratory page or redirect to another site?
+        res.send('Success!');
+    }
+};
+
+exports.getSlackToken = function(teamId) {};
+
+const saveSlackToken = function(teamId, token) {
+    let client = pool.connect();
+};

--- a/bot/slackAuth.js
+++ b/bot/slackAuth.js
@@ -1,8 +1,22 @@
 require('dotenv').config();
-const fetch = require('node-fetch');
-const { Pool, Client } = require('pg');
 
-const pool = new Pool(process.env.DATABASE_URL);
+const crypto = require('crypto');
+const fetch = require('node-fetch');
+const { Pool } = require('pg');
+const { getDbConfig } = require('./dbConfig');
+
+const pool = new Pool(getDbConfig());
+const RESIZED_IV = Buffer.allocUnsafe(16);
+const KEY = crypto
+    .createHash('sha256')
+    .update(process.env.CIPHER_KEY)
+    .digest();
+const IV = crypto
+    .createHash('sha256')
+    .update(process.env.CIPHER_IV)
+    .digest();
+
+IV.copy(RESIZED_IV);
 
 exports.authResponse = async function(req, res) {
     const { code } = req.query;
@@ -16,20 +30,85 @@ exports.authResponse = async function(req, res) {
         '&redirect_uri=' +
         process.env.SLACK_REDIRECT_URI;
     const authResponse = await fetch(slackURL).then(res => res.json());
-    console.log('authResponse', authResponse);
+
     if (!authResponse.ok) {
         console.log(authResponse);
         res.send('Error encountered: \n' + JSON.stringify(authResponse))
             .status(200)
             .end();
     } else {
-        // TO DO: better celebratory page or redirect to another site?
-        res.send('Success!');
+        const {
+            team: { id },
+            access_token
+        } = authResponse;
+        console.log('authResponse', authResponse);
+        const saveSuccess = await saveSlackToken(id, access_token);
+
+        if (saveSuccess) {
+            // TO DO: better celebratory page or redirect to another site?
+            res.send('Success!');
+        }
+
+        // TO DO: better error messaging if no save success
     }
 };
 
-exports.getSlackToken = function(teamId) {};
+const decryptToken = function(encryptedToken) {
+    const decipher = crypto.createDecipheriv('aes256', KEY, RESIZED_IV);
+    let slackToken = decipher.update(encryptedToken, 'hex', 'binary');
 
-const saveSlackToken = function(teamId, token) {
-    let client = pool.connect();
+    slackToken += decipher.final('binary');
+
+    return slackToken;
+};
+
+const encryptToken = function(token) {
+    const cipher = crypto.createCipheriv('aes256', KEY, RESIZED_IV);
+    let encryptedToken = cipher.update(token, 'binary', 'hex');
+
+    encryptedToken += cipher.final('hex');
+
+    return encryptedToken;
+};
+
+exports.getSlackToken = async function(teamId) {
+    let slackToken = null;
+    let client = await pool.connect();
+    const { token } = await client
+        .query('SELECT token FROM tokens WHERE team_id = $1', [teamId])
+        .then(res => {
+            client.release();
+            return res.rows[0];
+        })
+        .catch(e => {
+            client.release();
+            console.error(e.stack);
+            return null;
+        });
+
+    if (token) {
+        slackToken = decryptToken(token);
+    }
+
+    return slackToken;
+};
+
+const saveSlackToken = async function(teamId, token) {
+    let client = await pool.connect();
+    const botToken = encryptToken(token);
+
+    return client
+        .query('INSERT INTO tokens (team_id, token) VALUES ($1, $2)', [
+            teamId,
+            botToken
+        ])
+        .then(() => {
+            client.release();
+            return true;
+        })
+        .catch(e => {
+            client.release();
+            console.error(e.stack);
+            return false;
+        });
 };

--- a/bot/slackEvents.js
+++ b/bot/slackEvents.js
@@ -10,6 +10,7 @@ slackEvents.on('message', async event => {
         confirmThankYou(text, channel, team);
     }
 });
+
 slackEvents.on('error', console.error);
 
 module.exports = slackEvents;

--- a/bot/slackEvents.js
+++ b/bot/slackEvents.js
@@ -4,10 +4,10 @@ const { confirmThankYou } = require('./slackWeb');
 const slackEvents = createEventAdapter(process.env.SLACK_SIGNING_SECRET);
 
 slackEvents.on('message', async event => {
-    const { channel, text } = event;
+    const { channel, team, text } = event;
 
     if (event.channel_type === 'im' && event.client_msg_id) {
-        confirmThankYou(text, channel);
+        confirmThankYou(text, channel, team);
     }
 });
 slackEvents.on('error', console.error);

--- a/bot/slackWeb.js
+++ b/bot/slackWeb.js
@@ -7,8 +7,10 @@ const webAPI = {
      * send message that repeats the thank you text to confirm spelling
      */
     confirmThankYou: async function(tyText, channel, team) {
-        const token = await getSlackToken(team);
-        webAPI.slackWeb = new WebClient(token);
+        if (!webAPI.slackWeb) {
+            const token = await getSlackToken(team);
+            webAPI.slackWeb = new WebClient(token);
+        }
 
         try {
             await webAPI.slackWeb.chat.postMessage({
@@ -75,6 +77,13 @@ const webAPI = {
 
         return intro;
     },
+    initWeb: async function(token) {
+        webAPI.slackWeb = new WebClient(token);
+        const { channels } = await webAPI.slackWeb.conversations.list();
+        const { id } = channels.find(({ is_general }) => is_general);
+
+        await webAPI.slackWeb.conversations.join({ channel: id });
+    },
     slackWeb: null,
     /*
      * store message along with sender's display name
@@ -85,7 +94,6 @@ const webAPI = {
             .hour(12)
             .minute(0)
             .add(7, 'day');
-
         const previousTy = await webAPI.getExistingThankYou();
         const previousText = previousTy ? previousTy.text : null;
         const tyText = webAPI.formatThankYou(

--- a/bot/slackWeb.js
+++ b/bot/slackWeb.js
@@ -1,122 +1,127 @@
 const dayjs = require('dayjs');
 const { WebClient } = require('@slack/web-api');
+const { getSlackToken } = require('./slackAuth.js');
 
-const slackWeb = new WebClient(process.env.SLACK_TOKEN);
+const webAPI = {
+    /**
+     * send message that repeats the thank you text to confirm spelling
+     */
+    confirmThankYou: async function(tyText, channel, team) {
+        const token = await getSlackToken(team);
+        webAPI.slackWeb = new WebClient(token);
 
-function formatThankYou(tyObj, previousText = null) {
-    let intro =
-        previousText ||
-        '✨🙏✨ We have some thank yous this week, hooray! ✨☺️✨';
-
-    for (const [name, text] of Object.entries(tyObj)) {
-        intro += `\n - ${name} says ${text}`;
-    }
-
-    return intro;
-}
-
-async function getExistingThankYou() {
-    let { scheduled_messages } = await slackWeb.chat.scheduledMessages.list();
-
-    if (scheduled_messages.length) {
-        return scheduled_messages.find(({ text }) => {
-            return text.includes('We have some thank yous');
-        });
-    }
-
-    return null;
-}
-
-/*
- * store message along with sender's display name
- */
-exports.storeThankYou = async function(user, text) {
-    const nextMonday = dayjs()
-        .day(1)
-        .hour(12)
-        .minute(0)
-        .add(7, 'day');
-
-    const previousTy = await getExistingThankYou();
-    const previousText = previousTy ? previousTy.text : null;
-    const tyText = formatThankYou(
-        { [`@${user.username}`]: text },
-        previousText
-    );
-
-    if (previousTy) {
-        slackWeb.chat.deleteScheduledMessage({
-            channel: previousTy.channel_id,
-            scheduled_message_id: previousTy.id
-        });
-    }
-
-    try {
-        await slackWeb.chat.scheduleMessage({
-            channel: '#general',
-            text: tyText,
-            post_at: nextMonday.unix(),
-            link_names: true
-        });
-    } catch (error) {
-        console.log(error);
-    }
-};
-
-/**
- * send message that repeats the thank you text to confirm spelling
- */
-exports.confirmThankYou = async function(tyText, channel) {
-    try {
-        await slackWeb.chat.postMessage({
-            channel,
-            blocks: [
-                {
-                    type: 'section',
-                    text: {
-                        type: 'mrkdwn',
-                        text: `
-                        Thank you for your thank you! Before I pass your appreciation along, do I have this message right? \n \`${tyText}\`
-                        `
-                    }
-                },
-                {
-                    type: 'actions',
-                    elements: [
-                        {
-                            type: 'button',
-                            text: {
-                                type: 'plain_text',
-                                text: 'Confirm'
-                            },
-                            style: 'primary',
-                            value: tyText
-                        },
-                        {
-                            type: 'button',
-                            text: {
-                                type: 'plain_text',
-                                text: 'Cancel'
-                            },
-                            value: 'cancel'
+        try {
+            await webAPI.slackWeb.chat.postMessage({
+                channel,
+                blocks: [
+                    {
+                        type: 'section',
+                        text: {
+                            type: 'mrkdwn',
+                            text: `
+                            Thank you for your thank you! Before I pass your appreciation along, do I have this message right? \n \`${tyText}\`
+                            `
                         }
-                    ]
-                }
-            ]
-        });
-    } catch (error) {
-        console.log(error);
+                    },
+                    {
+                        type: 'actions',
+                        elements: [
+                            {
+                                type: 'button',
+                                text: {
+                                    type: 'plain_text',
+                                    text: 'Confirm'
+                                },
+                                style: 'primary',
+                                value: tyText
+                            },
+                            {
+                                type: 'button',
+                                text: {
+                                    type: 'plain_text',
+                                    text: 'Cancel'
+                                },
+                                value: 'cancel'
+                            }
+                        ]
+                    }
+                ]
+            });
+        } catch (error) {
+            console.log(error);
+        }
+    },
+    getExistingThankYou: async function() {
+        let {
+            scheduled_messages
+        } = await webAPI.slackWeb.chat.scheduledMessages.list();
+
+        if (scheduled_messages.length) {
+            return scheduled_messages.find(({ text }) => {
+                return text.includes('We have some thank yous');
+            });
+        }
+
+        return null;
+    },
+    formatThankYou: function(tyObj, previousText = null) {
+        let intro =
+            previousText ||
+            '✨🙏✨ We have some thank yous this week, hooray! ✨☺️✨';
+
+        for (const [name, text] of Object.entries(tyObj)) {
+            intro += `\n - ${name} says ${text}`;
+        }
+
+        return intro;
+    },
+    slackWeb: null,
+    /*
+     * store message along with sender's display name
+     */
+    storeThankYou: async function(user, text) {
+        const nextMonday = dayjs()
+            .day(1)
+            .hour(12)
+            .minute(0)
+            .add(7, 'day');
+
+        const previousTy = await webAPI.getExistingThankYou();
+        const previousText = previousTy ? previousTy.text : null;
+        const tyText = webAPI.formatThankYou(
+            { [`@${user.username}`]: text },
+            previousText
+        );
+
+        if (previousTy) {
+            webAPI.slackWeb.chat.deleteScheduledMessage({
+                channel: previousTy.channel_id,
+                scheduled_message_id: previousTy.id
+            });
+        }
+
+        try {
+            await webAPI.slackWeb.chat.scheduleMessage({
+                channel: '#general',
+                text: tyText,
+                post_at: nextMonday.unix(),
+                link_names: true
+            });
+        } catch (error) {
+            console.log(error);
+        }
+    },
+    tyReminder: async function() {
+        try {
+            await webAPI.slackWeb.chat.postMessage({
+                channel: '#general',
+                text:
+                    '👋 Howdy! Feeling like someone in this community has been helpful or kind this week? Send thanksbot a direct message to acknowledge this person! Your shout out will be posted on Monday 💪 🎉'
+            });
+        } catch (error) {
+            console.log(error);
+        }
     }
 };
 
-exports.tyReminder = async function() {
-    try {
-        await slackWeb.chat.postMessage({
-            channel: '#general',
-            text:
-                '👋 Howdy! Feeling like someone in this community has been helpful or kind this week? Send thanksbot a direct message to acknowledge this person! Your shout out will be posted on Monday 💪 🎉'
-        });
-    } catch (error) {
-        console.log(error);
-    }
-};
+module.exports = webAPI;

--- a/database.json
+++ b/database.json
@@ -1,0 +1,12 @@
+{
+    "init": {
+        "driver": "pg"
+    },
+    "dev": {
+        "driver": "pg",
+        "user": "ty",
+        "password": "thankyou",
+        "host": "localhost",
+        "database": "thanksbot"
+    }
+}

--- a/index.js
+++ b/index.js
@@ -19,6 +19,11 @@ const reminderMessage = new CronJob(
 
 app.use('/slack/events', slackEvents.requestListener());
 app.use('/slack/interactions', slackInteractions.requestListener());
+app.use('/slack/auth', (req, res) => {
+    console.log('req', req);
+});
+
 reminderMessage.start();
+
 
 app.listen(port, () => console.log(`Listening on ${port}`));

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const CronJob = require('cron').CronJob;
-const request = require('request');
+const { authResponse } = require('./bot/slackAuth.js');
 const slackInteractions = require('./bot/slackInteractions');
 const slackEvents = require('./bot/slackEvents');
 const { tyReminder } = require('./bot/slackWeb');
@@ -20,30 +20,8 @@ const reminderMessage = new CronJob(
 
 app.use('/slack/events', slackEvents.requestListener());
 app.use('/slack/interactions', slackInteractions.requestListener());
-app.get('/slack/auth', (req, res) => {
-    const { code } = req.query;
-
-    const options = {
-        uri: 'https://slack.com/api/oauth.access?code='
-            +code+
-            '&client_id='+process.env.SLACK_CLIENT_ID+
-            '&client_secret='+process.env.SLACK_CLIENT_SECRET+
-            '&redirect_uri='+process.env.SLACK_REDIRECT_URI,
-        method: 'GET'
-    }
-    request(options, (error, response, body) => {
-        var JSONresponse = JSON.parse(body)
-        if (!JSONresponse.ok){
-            console.log(JSONresponse)
-            res.send("Error encountered: \n"+JSON.stringify(JSONresponse)).status(200).end()
-        }else{
-            console.log('JSONresponse', JSONresponse)
-            res.send("Success!")
-        }
-    })
-});
+app.get('/slack/auth', authResponse);
 
 reminderMessage.start();
-
 
 app.listen(port, () => console.log(`Listening on ${port}`));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const CronJob = require('cron').CronJob;
+const request = require('request');
 const slackInteractions = require('./bot/slackInteractions');
 const slackEvents = require('./bot/slackEvents');
 const { tyReminder } = require('./bot/slackWeb');
@@ -19,8 +20,27 @@ const reminderMessage = new CronJob(
 
 app.use('/slack/events', slackEvents.requestListener());
 app.use('/slack/interactions', slackInteractions.requestListener());
-app.use('/slack/auth', (req, res) => {
-    console.log('req', req);
+app.get('/slack/auth', (req, res) => {
+    const { code } = req.query;
+
+    const options = {
+        uri: 'https://slack.com/api/oauth.access?code='
+            +code+
+            '&client_id='+process.env.SLACK_CLIENT_ID+
+            '&client_secret='+process.env.SLACK_CLIENT_SECRET+
+            '&redirect_uri='+process.env.SLACK_REDIRECT_URI,
+        method: 'GET'
+    }
+    request(options, (error, response, body) => {
+        var JSONresponse = JSON.parse(body)
+        if (!JSONresponse.ok){
+            console.log(JSONresponse)
+            res.send("Error encountered: \n"+JSON.stringify(JSONresponse)).status(200).end()
+        }else{
+            console.log('JSONresponse', JSONresponse)
+            res.send("Success!")
+        }
+    })
 });
 
 reminderMessage.start();

--- a/migrations/20200322210245-create-token-table.js
+++ b/migrations/20200322210245-create-token-table.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function(db) {
+    return db.createTable('tokens', {
+        columns: {
+            team_id: { type: 'string', primaryKey: true, unique: true },
+            token: 'string'
+        },
+        ifNotExists: true
+    });
+};
+
+exports.down = function(db) {
+    return db.dropTable('tokens', { ifExists: true });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,7 +271,6 @@
             "version": "6.12.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
             "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
-            "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -376,6 +375,19 @@
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
         "astral-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -386,6 +398,16 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "aws4": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
         },
         "axios": {
             "version": "0.19.2",
@@ -400,6 +422,14 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
         },
         "binary-extensions": {
             "version": "2.0.0",
@@ -539,6 +569,11 @@
             "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
             "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
             "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chalk": {
             "version": "2.4.2",
@@ -681,6 +716,11 @@
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
         "create-error-class": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -716,6 +756,14 @@
             "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
             "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
             "dev": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
         },
         "dayjs": {
             "version": "1.8.22",
@@ -790,6 +838,15 @@
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
             "dev": true
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
         },
         "ee-first": {
             "version": "1.1.1",
@@ -1094,6 +1151,11 @@
                 }
             }
         },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
         "external-editor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -1105,11 +1167,15 @@
                 "tmp": "^0.0.33"
             }
         },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
         "fast-deep-equal": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-            "dev": true
+            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
         },
         "fast-diff": {
             "version": "1.2.0",
@@ -1120,8 +1186,7 @@
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -1214,6 +1279,11 @@
                 "debug": "=3.1.0"
             }
         },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
         "form-data": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -1269,6 +1339,14 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
         },
         "glob": {
             "version": "7.1.6",
@@ -1335,6 +1413,20 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
             "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
         },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1356,6 +1448,16 @@
                 "setprototypeof": "1.1.1",
                 "statuses": ">= 1.5.0 < 2",
                 "toidentifier": "1.0.0"
+            }
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "iconv-lite": {
@@ -1642,6 +1744,11 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -1652,6 +1759,11 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -1669,11 +1781,20 @@
                 "esprima": "^4.0.0"
             }
         },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -1681,11 +1802,27 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
         "jsonc-parser": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
             "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
             "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
         },
         "latest-version": {
             "version": "3.1.0",
@@ -1964,6 +2101,11 @@
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
         "on-finished": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -2118,6 +2260,11 @@
                 "pinkie-promise": "^2.0.0"
             }
         },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
         "picomatch": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
@@ -2190,6 +2337,11 @@
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
             "dev": true
         },
+        "psl": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+            "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+        },
         "pstree.remy": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.7.tgz",
@@ -2199,8 +2351,7 @@
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "qs": {
             "version": "6.7.0",
@@ -2319,6 +2470,50 @@
             "dev": true,
             "requires": {
                 "rc": "^1.0.1"
+            }
+        },
+        "request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+                }
             }
         },
         "require-directory": {
@@ -2548,6 +2743,22 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
         "statuses": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -2711,6 +2922,15 @@
                 "nopt": "~1.0.10"
             }
         },
+        "tough-cookie": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            }
+        },
         "tslib": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -2721,6 +2941,19 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
             "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "type-check": {
             "version": "0.3.2",
@@ -2808,7 +3041,6 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -2826,6 +3058,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+        },
+        "uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "v8-compile-cache": {
             "version": "2.1.0",
@@ -2846,6 +3083,16 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
         },
         "vscode-json-languageservice": {
             "version": "3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,6 +271,7 @@
             "version": "6.12.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
             "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+            "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -346,7 +347,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
             }
@@ -383,31 +383,21 @@
                 "safer-buffer": "~2.1.0"
             }
         },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
         "astral-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
             "dev": true
         },
+        "async": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "aws4": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
         },
         "axios": {
             "version": "0.19.2",
@@ -420,22 +410,18 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
-        },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "binary-extensions": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
             "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
             "dev": true
+        },
+        "bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
         },
         "body-parser": {
             "version": "1.19.0",
@@ -533,7 +519,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -547,6 +532,11 @@
             "requires": {
                 "fill-range": "^7.0.1"
             }
+        },
+        "buffer-writer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+            "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
         },
         "bytes": {
             "version": "3.1.0",
@@ -570,16 +560,10 @@
             "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
             "dev": true
         },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
         "chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -654,7 +638,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -662,8 +645,12 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "colors": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -676,8 +663,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "configstore": {
             "version": "3.1.2",
@@ -716,11 +702,6 @@
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
-        "core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
         "create-error-class": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -742,7 +723,6 @@
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-            "dev": true,
             "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -757,18 +737,69 @@
             "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
             "dev": true
         },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
+        "cycle": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
         },
         "dayjs": {
             "version": "1.8.22",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.22.tgz",
             "integrity": "sha512-N8IXfxBD62Y9cKTuuuSoOlCXRnnzaTj1vu91r855iq6FbY5cZqOZnW/95nUn6kJiR+W9PHHrLykEoQOe6fUKxQ=="
+        },
+        "db-migrate": {
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/db-migrate/-/db-migrate-0.11.6.tgz",
+            "integrity": "sha512-HdX4V/RFVSFE+9XjiVZ3K6ofTXtd8KAam+IE14ln+1RWLGUJ1Qo8HFjEs6H3u01yRnCzvHGU0/oNkllf+ZtjVA==",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "bluebird": "^3.1.1",
+                "db-migrate-shared": "^1.2.0",
+                "deep-extend": "^0.6.0",
+                "dotenv": "^5.0.1",
+                "final-fs": "^1.6.0",
+                "inflection": "^1.10.0",
+                "mkdirp": "~0.5.0",
+                "optimist": "~0.6.1",
+                "parse-database-url": "~0.3.0",
+                "pkginfo": "^0.4.0",
+                "prompt": "^1.0.0",
+                "rc": "^1.2.8",
+                "resolve": "^1.1.6",
+                "semver": "^5.3.0",
+                "tunnel-ssh": "^4.0.0"
+            },
+            "dependencies": {
+                "dotenv": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+                    "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+                }
+            }
+        },
+        "db-migrate-base": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/db-migrate-base/-/db-migrate-base-2.1.1.tgz",
+            "integrity": "sha512-VFqAeVJ1Bf5Vo5Y5RfgXI/E3GuVYVwwATMAy7Cd/1HsE8WPXm0YkRGmywQ5RboqFqaeSCdRf8RmEFoomKCtlMw==",
+            "requires": {
+                "bluebird": "^3.1.1"
+            }
+        },
+        "db-migrate-pg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/db-migrate-pg/-/db-migrate-pg-1.0.0.tgz",
+            "integrity": "sha512-mdkT1KY8uE+uEWNEznXvhYGu8xQUGLgI+LiXk+2OyDvqoSl87RWKSLF8UaJTgqtl62f6BatMUymGNTzMSSRpuA==",
+            "requires": {
+                "bluebird": "^3.1.1",
+                "db-migrate-base": "^2.0.0",
+                "pg": "^7.8.0",
+                "semver": "^5.0.3"
+            }
+        },
+        "db-migrate-shared": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/db-migrate-shared/-/db-migrate-shared-1.2.0.tgz",
+            "integrity": "sha512-65k86bVeHaMxb2L0Gw3y5V+CgZSRwhVQMwDMydmw5MvIpHHwD6SmBciqIwHsZfzJ9yzV/yYhdRefRM6FV5/siw=="
         },
         "debug": {
             "version": "3.1.0",
@@ -783,17 +814,29 @@
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
+        "deep-equal": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+            "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+        },
         "deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "dev": true
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -839,15 +882,6 @@
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
             "dev": true
         },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -872,6 +906,34 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-abstract": {
+            "version": "1.17.5",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+            "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+            "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.1.5",
+                "is-regex": "^1.0.5",
+                "object-inspect": "^1.7.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.0",
+                "string.prototype.trimleft": "^2.1.1",
+                "string.prototype.trimright": "^2.1.1"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -880,8 +942,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
             "version": "6.8.0",
@@ -1151,11 +1212,6 @@
                 }
             }
         },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
         "external-editor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -1167,15 +1223,16 @@
                 "tmp": "^0.0.33"
             }
         },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        "eyes": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
         },
         "fast-deep-equal": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "dev": true
         },
         "fast-diff": {
             "version": "1.2.0",
@@ -1186,7 +1243,8 @@
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -1219,6 +1277,15 @@
             "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
+            }
+        },
+        "final-fs": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/final-fs/-/final-fs-1.6.1.tgz",
+            "integrity": "sha1-1tzZLvb+T+jAer1WjHE1YQ7eMjY=",
+            "requires": {
+                "node-fs": "~0.1.5",
+                "when": "~2.0.1"
             }
         },
         "finalhandler": {
@@ -1279,11 +1346,6 @@
                 "debug": "=3.1.0"
             }
         },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
         "form-data": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -1307,8 +1369,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "2.1.2",
@@ -1316,6 +1377,11 @@
             "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
             "dev": true,
             "optional": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -1340,19 +1406,10 @@
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true
         },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
         "glob": {
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
             "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -1413,25 +1470,23 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
             "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
         },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-        },
-        "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
+                "function-bind": "^1.1.1"
             }
         },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "hosted-git-info": {
             "version": "2.8.8",
@@ -1450,15 +1505,10 @@
                 "toidentifier": "1.0.0"
             }
         },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            }
+        "i": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+            "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
         },
         "iconv-lite": {
             "version": "0.4.24",
@@ -1502,11 +1552,15 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "inflection": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+            "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -1520,8 +1574,7 @@
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-            "dev": true
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "inquirer": {
             "version": "7.1.0",
@@ -1652,6 +1705,11 @@
                 "binary-extensions": "^2.0.0"
             }
         },
+        "is-callable": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+            "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+        },
         "is-ci": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
@@ -1660,6 +1718,11 @@
             "requires": {
                 "ci-info": "^1.5.0"
             }
+        },
+        "is-date-object": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -1733,6 +1796,14 @@
             "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
             "dev": true
         },
+        "is-regex": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+            "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
         "is-retry-allowed": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
@@ -1744,10 +1815,13 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        "is-symbol": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+            "requires": {
+                "has-symbols": "^1.0.1"
+            }
         },
         "is-utf8": {
             "version": "0.2.1",
@@ -1757,8 +1831,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isstream": {
             "version": "0.1.2",
@@ -1781,20 +1854,16 @@
                 "esprima": "^4.0.0"
             }
         },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-        },
-        "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -1802,27 +1871,11 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
         "jsonc-parser": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
             "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
             "dev": true
-        },
-        "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-            }
         },
         "latest-version": {
             "version": "3.1.0",
@@ -1868,6 +1921,11 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
             "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
+        },
+        "lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
         },
         "lodash.isfunction": {
             "version": "3.0.9",
@@ -1927,6 +1985,11 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
+        "memorystream": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+            "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
+        },
         "merge-descriptors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -1965,7 +2028,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -1973,14 +2035,12 @@
         "minimist": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             }
@@ -1998,6 +2058,11 @@
                 "moment": ">= 2.9.0"
             }
         },
+        "mongodb-uri": {
+            "version": "0.9.7",
+            "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
+            "integrity": "sha1-D3ca0W9IOuZfQoeWlCjp+8SqYYE="
+        },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2006,14 +2071,18 @@
         "mute-stream": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-            "dev": true
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
         },
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
+        },
+        "ncp": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+            "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
         },
         "negotiator": {
             "version": "0.6.2",
@@ -2023,8 +2092,17 @@
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-            "dev": true
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+        },
+        "node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "node-fs": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/node-fs/-/node-fs-0.1.7.tgz",
+            "integrity": "sha1-MjI8zLRsn78PwRgS1FAhzDHTJbs="
         },
         "nodemon": {
             "version": "2.0.2",
@@ -2087,6 +2165,72 @@
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
         },
+        "npm-run-all": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+            "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "memorystream": "^0.3.1",
+                "minimatch": "^3.0.4",
+                "pidtree": "^0.3.0",
+                "read-pkg": "^3.0.0",
+                "shell-quote": "^1.6.1",
+                "string.prototype.padend": "^3.0.0"
+            },
+            "dependencies": {
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+                }
+            }
+        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -2101,10 +2245,26 @@
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
-        "oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        "object-inspect": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
         },
         "on-finished": {
             "version": "2.3.0",
@@ -2118,7 +2278,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -2130,6 +2289,15 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             }
         },
         "optionator": {
@@ -2192,6 +2360,11 @@
                 "semver": "^5.1.0"
             }
         },
+        "packet-reader": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+            "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+        },
         "parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2199,6 +2372,14 @@
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
+            }
+        },
+        "parse-database-url": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/parse-database-url/-/parse-database-url-0.3.0.tgz",
+            "integrity": "sha1-NpZmMh6SfJreY838Gqr2+zdFPQ0=",
+            "requires": {
+                "mongodb-uri": ">= 0.9.7"
             }
         },
         "parse-json": {
@@ -2225,8 +2406,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -2237,8 +2417,7 @@
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-            "dev": true
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-parse": {
             "version": "1.0.6",
@@ -2260,16 +2439,78 @@
                 "pinkie-promise": "^2.0.0"
             }
         },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        "pg": {
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
+            "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
+            "requires": {
+                "buffer-writer": "2.0.0",
+                "packet-reader": "1.0.0",
+                "pg-connection-string": "0.1.3",
+                "pg-packet-stream": "^1.1.0",
+                "pg-pool": "^2.0.10",
+                "pg-types": "^2.1.0",
+                "pgpass": "1.x",
+                "semver": "4.3.2"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+                    "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+                }
+            }
+        },
+        "pg-connection-string": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+            "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+        },
+        "pg-int8": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+            "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+        },
+        "pg-packet-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+            "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
+        },
+        "pg-pool": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+            "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
+        },
+        "pg-types": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+            "requires": {
+                "pg-int8": "1.0.1",
+                "postgres-array": "~2.0.0",
+                "postgres-bytea": "~1.0.0",
+                "postgres-date": "~1.0.4",
+                "postgres-interval": "^1.1.0"
+            }
+        },
+        "pgpass": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+            "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+            "requires": {
+                "split": "^1.0.0"
+            }
         },
         "picomatch": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
             "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
             "dev": true
+        },
+        "pidtree": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
+            "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg=="
         },
         "pify": {
             "version": "2.3.0",
@@ -2287,6 +2528,34 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
                 "pinkie": "^2.0.0"
+            }
+        },
+        "pkginfo": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+            "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+        },
+        "postgres-array": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+        },
+        "postgres-bytea": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+            "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+        },
+        "postgres-date": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
+            "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+        },
+        "postgres-interval": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+            "requires": {
+                "xtend": "^4.0.0"
             }
         },
         "prelude-ls": {
@@ -2322,6 +2591,19 @@
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
+        "prompt": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+            "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+            "requires": {
+                "colors": "^1.1.2",
+                "pkginfo": "0.x.x",
+                "read": "1.0.x",
+                "revalidator": "0.1.x",
+                "utile": "0.3.x",
+                "winston": "2.1.x"
+            }
+        },
         "proxy-addr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -2337,11 +2619,6 @@
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
             "dev": true
         },
-        "psl": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-            "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
-        },
         "pstree.remy": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.7.tgz",
@@ -2351,7 +2628,8 @@
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
         },
         "qs": {
             "version": "6.7.0",
@@ -2397,7 +2675,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "dev": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -2408,15 +2685,21 @@
                 "minimist": {
                     "version": "1.2.3",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-                    "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-                    "dev": true
+                    "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "dev": true
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
                 }
+            }
+        },
+        "read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "requires": {
+                "mute-stream": "~0.0.4"
             }
         },
         "read-pkg": {
@@ -2472,50 +2755,6 @@
                 "rc": "^1.0.1"
             }
         },
-        "request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "dependencies": {
-                "form-data": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.6",
-                        "mime-types": "^2.1.12"
-                    }
-                },
-                "qs": {
-                    "version": "6.5.2",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-                }
-            }
-        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2555,11 +2794,15 @@
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
             "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
         },
+        "revalidator": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+            "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
+        },
         "rimraf": {
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
             "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-            "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -2673,7 +2916,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -2681,8 +2923,12 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "shell-quote": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
         },
         "signal-exit": {
             "version": "3.0.2",
@@ -2737,32 +2983,52 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
             "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
         },
+        "split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "requires": {
+                "through": "2"
+            }
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
-        "sshpk": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+        "ssh2": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.4.tgz",
+            "integrity": "sha1-G/a2soyW6u8mf01sRqWiUXpZnic=",
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "ssh2-streams": "~0.1.15"
             }
+        },
+        "ssh2-streams": {
+            "version": "0.1.20",
+            "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
+            "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
+            "requires": {
+                "asn1": "~0.2.0",
+                "semver": "^5.1.0",
+                "streamsearch": "~0.1.2"
+            }
+        },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
         },
         "statuses": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        },
+        "streamsearch": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+            "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
         },
         "string-width": {
             "version": "1.0.2",
@@ -2772,6 +3038,33 @@
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
                 "strip-ansi": "^3.0.0"
+            }
+        },
+        "string.prototype.padend": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
+            "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
+            }
+        },
+        "string.prototype.trimleft": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+            "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "string.prototype.trimright": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+            "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
             }
         },
         "strip-ansi": {
@@ -2806,7 +3099,6 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
             }
@@ -2881,8 +3173,7 @@
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "timed-out": {
             "version": "4.0.1",
@@ -2922,15 +3213,6 @@
                 "nopt": "~1.0.10"
             }
         },
-        "tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            }
-        },
         "tslib": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -2942,18 +3224,25 @@
             "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
             "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
         },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+        "tunnel-ssh": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/tunnel-ssh/-/tunnel-ssh-4.1.4.tgz",
+            "integrity": "sha512-CjBqboGvAbM7iXSX2F95kzoI+c2J81YkrHbyyo4SWNKCzU6w5LfEvXBCHu6PPriYaNvfhMKzD8bFf5Vl14YTtg==",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "debug": "2.6.9",
+                "lodash.defaults": "^4.1.0",
+                "ssh2": "0.5.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "type-check": {
             "version": "0.3.2",
@@ -3041,6 +3330,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -3054,15 +3344,23 @@
                 "prepend-http": "^1.0.1"
             }
         },
+        "utile": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+            "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+            "requires": {
+                "async": "~0.9.0",
+                "deep-equal": "~0.2.1",
+                "i": "0.3.x",
+                "mkdirp": "0.x.x",
+                "ncp": "1.0.x",
+                "rimraf": "2.x.x"
+            }
+        },
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-        },
-        "uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "v8-compile-cache": {
             "version": "2.1.0",
@@ -3083,16 +3381,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-        },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
         },
         "vscode-json-languageservice": {
             "version": "3.5.1",
@@ -3131,11 +3419,15 @@
             "integrity": "sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A==",
             "dev": true
         },
+        "when": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/when/-/when-2.0.1.tgz",
+            "integrity": "sha1-jYcv4V5oQkyRtLck6EjggH2rZkI="
+        },
         "which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -3187,11 +3479,47 @@
                 }
             }
         },
+        "winston": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+            "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+            "requires": {
+                "async": "~1.0.0",
+                "colors": "1.0.x",
+                "cycle": "1.0.x",
+                "eyes": "0.1.x",
+                "isstream": "0.1.x",
+                "pkginfo": "0.3.x",
+                "stack-trace": "0.0.x"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+                },
+                "colors": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+                },
+                "pkginfo": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+                    "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+                }
+            }
+        },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         },
         "wrap-ansi": {
             "version": "2.1.0",
@@ -3205,8 +3533,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write": {
             "version": "1.0.3",
@@ -3233,6 +3560,11 @@
             "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
             "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
             "dev": true
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "y18n": {
             "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "cron": "^1.8.2",
         "dayjs": "^1.8.22",
         "dotenv": "^8.2.0",
-        "express": "^4.17.1"
+        "express": "^4.17.1",
+        "request": "^2.88.2"
     },
     "devDependencies": {
         "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,16 @@
     "description": "A bot to foster and celebrate a culture of appreciation",
     "main": "index.js",
     "scripts": {
+        "db-create-dev": "db-migrate --env init db:create thanksbot || echo \"Error setting up database\"",
+        "db-create-role-dev": "psql -d \"thanksbot\" -c \"CREATE ROLE ty WITH LOGIN PASSWORD 'thankyou'\" || echo \"Error creating role\"",
+        "db-init-local": "npm-run-all db-create-dev db-create-role-dev migrate-up",
         "dev": "nodemon index.js",
         "lint": "eslint --ext .json --ext .js .",
+        "migrate-create": "db-migrate create",
+        "migrate-up": "db-migrate up",
+        "migrate-down": "db-migrate down",
         "prettier": "prettier --write \"**/*.{js,json}\"",
-        "start": "node index.js"
+        "start": "npm-run-all migrate-up && node index.js"
     },
     "repository": {
         "type": "git",
@@ -25,9 +31,13 @@
         "@slack/web-api": "^5.8.0",
         "cron": "^1.8.2",
         "dayjs": "^1.8.22",
+        "db-migrate": "^0.11.6",
+        "db-migrate-pg": "^1.0.0",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
-        "request": "^2.88.2"
+        "node-fetch": "^2.6.0",
+        "npm-run-all": "^4.1.5",
+        "pg": "^7.18.2"
     },
     "devDependencies": {
         "eslint": "^6.8.0",


### PR DESCRIPTION
This PR adds @jorydotcom 's initial README plus:

-  An "Add to Slack" button in the README
- Adds auth endpoint for enabling app on multiple workspaces
- Logic for connecting to a postgres database locally
- adds db-migrate for handling migrations
- Add feature of encrypting, saving, and retrieving slack bot tokens for different teams