### PR TITLE
Send event response to prevent duplicate messages

### DIFF
--- a/bot/slackEvents.js
+++ b/bot/slackEvents.js
@@ -1,9 +1,15 @@
 const { createEventAdapter } = require('@slack/events-api');
 const slackWeb = require('./slackWeb');
 
-const slackEvents = createEventAdapter(process.env.SLACK_SIGNING_SECRET);
+const slackEvents = createEventAdapter(process.env.SLACK_SIGNING_SECRET, {
+    waitForResponse: true
+});
 
-slackEvents.on('message', async event => {
+slackEvents.on('message', (event, respond) => {
+    // Be sure to acknowledge the event to prevent duplicate
+    // message events: https://api.slack.com/events-api#graceful_retries
+    respond();
+
     const { channel, team, text } = event;
     const webAPI = new slackWeb(team);
 
@@ -12,6 +18,9 @@ slackEvents.on('message', async event => {
     }
 });
 
-slackEvents.on('error', console.error);
+slackEvents.on('error', (error, respond) => {
+    console.error(error);
+    respond(error, { status: 500 });
+});
 
 module.exports = slackEvents;

--- a/bot/slackInteractions.js
+++ b/bot/slackInteractions.js
@@ -24,7 +24,7 @@ slackInteractions.action({ type: 'button' }, (payload, respond) => {
     } else {
         respond({
             text:
-                'Message cancelled! Submit another thank you if you to publish your message.',
+                'Message cancelled! Submit another thank you if you wish to publish your message.',
             response_type: 'in_channel'
         });
     }


### PR DESCRIPTION
This PR adds a response to acknowledge Events API events in order to fix duplicate Slack event attempts. This should solve #19 (thanks for finding that, @jorydotcom !).

Here is the relevant Slack documentation: https://api.slack.com/events-api#graceful_retries